### PR TITLE
adds redirection for new domains

### DIFF
--- a/default
+++ b/default
@@ -3,5 +3,13 @@ server {
         listen [::]:80 default_server ipv6only=on;
         server_name shippable.com www.shippable.com;
 
+        rewrite        ^ https://www.shippable.com$request_uri? permanent;
+}
+
+server {
+        listen 80 default_server;
+        listen [::]:80 default_server ipv6only=on;
+        server_name app.shippable.com;
+
         rewrite        ^ https://app.shippable.com$request_uri? permanent;
 }


### PR DESCRIPTION
shippable.com, www.shippable.com redirects to https://www.shippable.com
app.shippable.com redirects to https://app.shippable.com

fixes:https://github.com/Shippable/rp/issues/5